### PR TITLE
Rename key in DIALECTS to fix filter enumeration in Falcon-Toolkit

### DIFF
--- a/caracara_filters/dialects/hosts.py
+++ b/caracara_filters/dialects/hosts.py
@@ -200,7 +200,7 @@ HOSTS_FILTERS: Dict[str, Dict[str, Any]] = {
     "deviceid": hosts_device_id_filter,
     "device_id": hosts_device_id_filter,  # pythonic
     "domain": hosts_domain_filter,
-    "external": hosts_external_ip_address_filter,
+    "externalip": hosts_external_ip_address_filter,
     "external_ip": hosts_external_ip_address_filter,  # pythonic
     "firstseen": hosts_first_seen_filter,
     "first_seen": hosts_first_seen_filter,  # pythonic


### PR DESCRIPTION
DIALECTS is used in Falcon-Toolkit and will fail when listing filters with `falcon filters` because the key `externalip` doesn't exist in the DIALECTS dict (enumeration of available filters is performed [by removing underscores from all keys in DIALECTS](https://github.com/CrowdStrike/Falcon-Toolkit/commit/737116c85e0d586fb0a79cc7dd1e343338249754#diff-e0dedbd1bf0499cf40ff233c4b68c3ab7dec3f7cdcd587c4c572aa86e1dea93fR284) and iterating through them).

By replacing `external` with `externalip`, this should not introduce any breaking changes and should restore functionality to the downstream project.